### PR TITLE
Enable Chefstyle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 # encoding: utf-8
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :development do
   gem "chefstyle", "0.13.0"
-  gem 'bundler'
-  gem 'byebug'
-  gem 'minitest'
-  gem 'rake'
+  gem "bundler"
+  gem "byebug"
+  gem "minitest"
+  gem "rake"
   gem "rubocop"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem "chefstyle", "0.13.0"
   gem 'bundler'
   gem 'byebug'
   gem 'minitest'
   gem 'rake'
-  gem 'rubocop', '= 0.49.1' # Need to keep in sync with main InSpec project, so config files will work
+  gem "rubocop"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -23,18 +23,14 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-#------------------------------------------------------------------#
-#                    Code Style Tasks
-#------------------------------------------------------------------#
-require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new(:lint) do |t|
-  # Choices of RuboCop rules to enforce are deeply personal.
-  # Here, we set things up so that your plugin will use the Bundler-installed
-  # inspec gem's copy of the InSpec project's rubocop.yml file (which
-  # is indeed packaged with the inspec gem).
-  require 'inspec/globals'
-  inspec_rubocop_yml = File.join(Inspec.src_root, '.rubocop.yml')
-
-  t.options = ['--display-cop-names', '--config', inspec_rubocop_yml]
+namespace(:test) do
+  #------------------------------------------------------------------#
+  #                    Code Style Tasks
+  #------------------------------------------------------------------#
+  require "chefstyle"
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:lint)
 end
+
+task default: [:'test:lint']

--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,13 @@
 
 # This task template will make a task named 'test', and run
 # the tests that it finds.
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.libs.push 'lib'
+  t.libs.push "lib"
   t.test_files = FileList[
-    'test/unit/*_test.rb',
-    'test/functional/*_test.rb',
+    "test/unit/*_test.rb",
+    "test/functional/*_test.rb",
   ]
   t.verbose = true
   # Ideally, we'd run tests with warnings enabled,
@@ -23,13 +23,12 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-
 namespace(:test) do
   #------------------------------------------------------------------#
   #                    Code Style Tasks
   #------------------------------------------------------------------#
   require "chefstyle"
-  require 'rubocop/rake_task'
+  require "rubocop/rake_task"
   RuboCop::RakeTask.new(:lint)
 end
 

--- a/inspec-input-vault.gemspec
+++ b/inspec-input-vault.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['InSpec Core Engineering']
   spec.email         = ['inspec@chef.io']
   spec.summary       = 'Use HashiCorp Vault data in your InSpec profiles'
-  spec.description   = '["This plugin allows InSpec 'inputs' to be provided by a HashiCorp Vault installation.  This enables you to unify your secrets management with your compliance automation.\n"]'
+  spec.description   = "This plugin allows InSpec 'inputs' to be provided by a HashiCorp Vault installation.  This enables you to unify your secrets management with your compliance automation."
   spec.homepage      = 'https://github.com/inspec/inspec-input-vault'
   spec.license       = 'Apache-2.0'
 

--- a/inspec-input-vault.gemspec
+++ b/inspec-input-vault.gemspec
@@ -6,23 +6,23 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'inspec-input-vault/version'
+require "inspec-input-vault/version"
 
 Gem::Specification.new do |spec|
   # Importantly, all InSpec plugins must be prefixed with `inspec-` (most
   # plugins) or `train-` (plugins which add new connectivity features).
-  spec.name          = 'inspec-input-vault'
+  spec.name          = "inspec-input-vault"
 
   # It is polite to namespace your plugin under InspecPlugins::YourPluginInCamelCase
   spec.version       = InspecPlugins::InputVault::VERSION
-  spec.authors       = ['InSpec Core Engineering']
-  spec.email         = ['inspec@chef.io']
-  spec.summary       = 'Use HashiCorp Vault data in your InSpec profiles'
+  spec.authors       = ["InSpec Core Engineering"]
+  spec.email         = ["inspec@chef.io"]
+  spec.summary       = "Use HashiCorp Vault data in your InSpec profiles"
   spec.description   = "This plugin allows InSpec 'inputs' to be provided by a HashiCorp Vault installation.  This enables you to unify your secrets management with your compliance automation."
-  spec.homepage      = 'https://github.com/inspec/inspec-input-vault'
-  spec.license       = 'Apache-2.0'
+  spec.homepage      = "https://github.com/inspec/inspec-input-vault"
+  spec.license       = "Apache-2.0"
 
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
@@ -30,9 +30,9 @@ Gem::Specification.new do |spec|
   spec.files = %w{
     README.md inspec_input_vault.gemspec Gemfile
   } + Dir.glob(
-    'lib/**/*', File::FNM_DOTMATCH
+    "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   # If you rely on any other gems, list them here with any constraints.
   # This is how `inspec plugin install` is able to manage your dependencies.
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
 
   # All plugins should mention inspec, > 2.2.78
   # 2.2.78 included the v2 Plugin API
-  spec.add_dependency 'inspec', '>=2.2.78', '<4.0.0'
+  spec.add_dependency "inspec", ">=2.2.78", "<4.0.0"
 end

--- a/lib/inspec-input-vault.rb
+++ b/lib/inspec-input-vault.rb
@@ -13,4 +13,4 @@
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
-require 'inspec-input-vault/plugin'
+require "inspec-input-vault/plugin"

--- a/lib/inspec-input-vault/cli_command.rb
+++ b/lib/inspec-input-vault/cli_command.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'inspec/resource'
+require "inspec/resource"
 
 module InspecPlugins::InputVault
   # This class will provide the actual CLI implementation.
@@ -23,7 +23,7 @@ module InspecPlugins::InputVault
     # Note: if you want your command (or subcommand) to have dashes in it,
     # use underscores where you want a dash, and Thor will convert them.
     # Thor will fail to find a command that is directly named with dashes.
-    subcommand_desc 'my_command [COMMAND]', 'Your Usage Message Here'
+    subcommand_desc "my_command [COMMAND]", "Your Usage Message Here"
 
     # The usual rhythm for a Thor CLI file is description, options, command method.
     # Thor just has you call DSL methods in sequence prior to each command.
@@ -36,18 +36,18 @@ module InspecPlugins::InputVault
     # in `inspec help my-command`.
     # As this is a usage message, you should write the command as it should appear
     # to the user (if you want it to have dashes, use dashes)
-    desc 'do-something WHAT [OPTIONS]', 'Does something'
+    desc "do-something WHAT [OPTIONS]", "Does something"
 
     # Let's include an option, -s, to summarize
     # Refer to the Thors docs; there is a lot you can do here.
-    option :summary, desc: 'Include a total at the bottom', \
+    option :summary, desc: "Include a total at the bottom", \
                      type: :boolean, default: true, aliases: [:s]
 
     # OK, now the actual method itself.  If you provide params, you're telling Thor that
     # you accept CLI arguments after all options have been consumed.
     # Note again that the method name has an underscore, but when invoked
     # on the CLI, use a dash.
-    def do_something(what = 'nothing')
+    def do_something(what = "nothing")
       # The code here will *only* be executed if someone actually
       # runs `inspec my-command do-something`.
 
@@ -57,7 +57,7 @@ module InspecPlugins::InputVault
       # Talk to the user using the `ui` object (see Inspec::UI)
       # ui.error('Whoops!')
 
-      ui.warning('This is a generated plugin with a default implementation.  Edit lib/inspec-input-vault/cli_command.rb to make it do what you want.')
+      ui.warning("This is a generated plugin with a default implementation.  Edit lib/inspec-input-vault/cli_command.rb to make it do what you want.")
       ui.exit(:success) # or :usage_error
     end
   end

--- a/lib/inspec-input-vault/plugin.rb
+++ b/lib/inspec-input-vault/plugin.rb
@@ -9,7 +9,7 @@
 # fast and light by only loading heavy things when they are needed.
 
 # Presumably this is light
-require 'inspec-input-vault/version'
+require "inspec-input-vault/version"
 
 # The InspecPlugins namespace is where all plugins should declare themselves.
 # The 'Inspec' capitalization is used throughout the InSpec source code; yes, it's
@@ -44,7 +44,7 @@ module InspecPlugins
         # functionality.
         # For example, InSpec will activate this hook when `inspec help` is
         # executed, so that this plugin's usage message will be included in the help.
-        require 'inspec-input-vault/cli_command'
+        require "inspec-input-vault/cli_command"
 
         # Having loaded our functionality, return a class that will let the
         # CLI engine tap into it.

--- a/lib/inspec-input-vault/version.rb
+++ b/lib/inspec-input-vault/version.rb
@@ -5,6 +5,6 @@
 # to learn the current version.
 module InspecPlugins
   module InputVault
-    VERSION = '0.1.0'.freeze
+    VERSION = "0.1.0".freeze
   end
 end

--- a/test/functional/inspec_input_vault_test.rb
+++ b/test/functional/inspec_input_vault_test.rb
@@ -4,11 +4,11 @@
 # Functional tests generally do not have inside knowledge of how the plugin works.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
-describe 'inspec list-resources core' do
+describe "inspec list-resources core" do
   # Our helper.rb locates this library from the InSpec install that
   # Bundler installed for us. If we want its methods, we still must
   # import it.  Including it here will make it available in all child
@@ -30,7 +30,7 @@ describe 'inspec list-resources core' do
     # think that this plugin we are currently testing is installed as a
     # user plugin, by writing a plugin config file in a temp dir.
     # To use it, just provide a command line, minus the word `inspec`.
-    let (:outcome) { run_inspec_process_with_this_plugin('listresources core') }
+    let(:outcome) { run_inspec_process_with_this_plugin("listresources core") }
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)
@@ -40,7 +40,7 @@ describe 'inspec list-resources core' do
 
     # A selection of core resources, just spot checking.
     # This is an example of using Ruby to define sets of tests.
-    ['process', 'service', 'user', 'file'].each do |resource_name|
+    %w{process service user file}.each do |resource_name|
       it "should mention the '#{resource_name}' resource" do
         outcome.stdout.must_include(resource_name)
       end
@@ -48,7 +48,7 @@ describe 'inspec list-resources core' do
 
     # Check for the summary
     it "should mention the summary" do
-      outcome.stdout.must_include('resources total')
+      outcome.stdout.must_include("resources total")
     end
   end
 
@@ -56,19 +56,19 @@ describe 'inspec list-resources core' do
   describe "when run with a search pattern that matches things" do
     # Notice that the command line is changed here:
     # "list all resources that have the word user in them"
-    let (:outcome) { run_inspec_process_with_this_plugin('listresources core user') }
+    let(:outcome) { run_inspec_process_with_this_plugin("listresources core user") }
 
     # Should be well-behaved...
     it("should exit successfully") { outcome.exit_status.must_equal(0) }
     it("should be silent on stderr") { outcome.stderr.must_be_empty }
 
     # Here, we want to know it DID match some things, and NOT some others.
-    ['user', 'users'].each do |resource_name|
+    %w{user users}.each do |resource_name|
       it "should mention the '#{resource_name}' resource" do
         outcome.stdout.must_include(resource_name)
       end
     end
-    ['process', 'service', 'file'].each do |resource_name|
+    %w{process service file}.each do |resource_name|
       it "should NOT mention the '#{resource_name}' resource" do
         outcome.stdout.wont_include(resource_name)
       end
@@ -76,7 +76,7 @@ describe 'inspec list-resources core' do
   end
   describe "when run with a search pattern that matches nothing" do
     # Unlikely we'll have a resource with the string 'autogyro' in it.
-    let (:outcome) { run_inspec_process_with_this_plugin('listresources core autogyro') }
+    let(:outcome) { run_inspec_process_with_this_plugin("listresources core autogyro") }
 
     # Should be well-behaved...
     it("should exit successfully") { outcome.exit_status.must_equal(0) }
@@ -89,14 +89,14 @@ describe 'inspec list-resources core' do
 
     # Check for the summary
     it "should mention a zero-resource summary" do
-      outcome.stdout.must_include('0 resources total')
+      outcome.stdout.must_include("0 resources total")
     end
   end
 
   # Exercise the summary option, which defaults to 'true'.
   describe "when run with the no-summary flag" do
     # Alter the command string to include the no-summary option
-    let(:outcome) { run_inspec_process_with_this_plugin('listresources core --no-summary') }
+    let(:outcome) { run_inspec_process_with_this_plugin("listresources core --no-summary") }
 
     # Should be well-behaved...
     it("should exit successfully") { outcome.exit_status.must_equal(0) }
@@ -104,7 +104,7 @@ describe 'inspec list-resources core' do
 
     # Check for the summary
     it "should NOT mention summary" do
-      outcome.stdout.wont_include('0 resources total')
+      outcome.stdout.wont_include("0 resources total")
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,11 +6,11 @@
 # InSpec core provides a number of such libraries and facilities, in the file
 # lib/plugins/shared/core_plugin_test_helper.rb . So, one job in this file is
 # to locate and load that file.
-require 'inspec/../plugins/shared/core_plugin_test_helper'
+require "inspec/../plugins/shared/core_plugin_test_helper"
 
 # Also load the InSpec plugin system. We need this so we can unit-test the plugin
 # classes, which will rely on the plugin system.
-require 'inspec/plugin/v2'
+require "inspec/plugin/v2"
 
 # Caution: loading all of InSpec (i.e. require 'inspec') may cause interference with
 # minitest/spec; one symptom would be appearing to have no tests.
@@ -19,8 +19,8 @@ require 'inspec/plugin/v2'
 # You can select from a number of test harnesses.  Since InSpec uses Spec-style controls
 # in profile code, you will probably want to use something like minitest/spec, which provides
 # Spec-style tests.
-require 'minitest/spec'
-require 'minitest/autorun'
+require "minitest/spec"
+require "minitest/autorun"
 
 # You might want to put some debugging tools here.  We run tests to find bugs, after all.
-require 'byebug'
+require "byebug"

--- a/test/unit/cli_args_test.rb
+++ b/test/unit/cli_args_test.rb
@@ -2,10 +2,10 @@
 # inspec-input-vault are correct.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Load the class under test, the CliCommand definition.
-require 'inspec-input-vault/cli_command'
+require "inspec-input-vault/cli_command"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.
@@ -24,10 +24,10 @@ describe InspecPlugins::InputVault::CliCommand do
   # modify and add to the lines below to test your actual options.
 
   # This is a Hash of Structs that tells us details of options for the 'do_something' subcommand.
-  let(:do_something_options) { cli_class.all_commands['do_something'].options }
+  let(:do_something_options) { cli_class.all_commands["do_something"].options }
 
   # To group tests together, you can nest 'describe' in minitest/spec
-  describe 'the do-something subcommand' do
+  describe "the do-something subcommand" do
 
     # Some tests through here use minitest Expectations, which attach to all
     # Objects, and begin with 'must' (positive) or 'wont' (negative)

--- a/test/unit/plugin_def_test.rb
+++ b/test/unit/plugin_def_test.rb
@@ -2,10 +2,10 @@
 # the inspec-resource-lister plugin is configured correctly.
 
 # Include our test harness
-require_relative '../helper'
+require_relative "../helper"
 
 # Load the class under test, the Plugin definition.
-require 'inspec-input-vault/plugin'
+require "inspec-input-vault/plugin"
 
 # Because InSpec is a Spec-style test suite, we're going to use MiniTest::Spec
 # here, for familiar look and feel. However, this isn't InSpec (or RSpec) code.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Enables chefstyle standardization, then applies it. 
Also fixes a syntax error in the gemspec.
Also arranges the rake tasks so we have the standard test:lint task, and it is selected as one of the defaults.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
