### PR TITLE
Add priority option

### DIFF
--- a/lib/inspec-vault/input.rb
+++ b/lib/inspec-vault/input.rb
@@ -9,17 +9,23 @@ module InspecPlugins::Vault
     attr_reader :mount_point
     attr_reader :path_prefix
     attr_reader :vault
+    attr_reader :priority
 
     def initialize
       @plugin_conf = Inspec::Config.cached.fetch_plugin_config("inspec-vault")
 
       @mount_point = fetch_plugin_setting("mount_point", "secret")
       @path_prefix = fetch_plugin_setting("path_prefix", "inspec")
+      @priority = fetch_plugin_setting("priority", 60).to_i
 
       @vault = Vault::Client.new(
         address: fetch_vault_setting("vault_addr"),
         token: fetch_vault_setting("vault_token")
       )
+    end
+
+    def default_priority
+      priority
     end
 
     # returns Array of input names as strings

--- a/test/fixtures/profiles/priority/controls/priority.rb
+++ b/test/fixtures/profiles/priority/controls/priority.rb
@@ -1,0 +1,25 @@
+
+# This control file is intended to be run twice -
+# once with the priority set to < 30, and once set to > 60.
+
+# An input that vault manages and has no interference
+control "priority_check_always_vault" do
+  describe input("priority_check_always_vault") do
+    it { should cmp "value_from_vault" }
+  end
+end
+
+# An input that vault and DSL conflict, but DSL should win
+control "priority_check_dsl_wins" do
+  describe input("priority_check_dsl_wins", value: "value_from_dsl", priority: 90) do
+    it { should cmp "value_from_dsl" }
+  end
+end
+
+# An input that vault and DSL conflict upon
+control "priority_check_variable_outcome" do
+  describe input("priority_check_variable_outcome", value: "value_from_dsl", priority: 30) do
+    it { should cmp "value_from_dsl" }   # Matches when run with vault on low priority
+    it { should cmp "value_from_vault" } # Matches when run with vault on high priority
+  end
+end

--- a/test/fixtures/profiles/priority/inspec.yml
+++ b/test/fixtures/profiles/priority/inspec.yml
@@ -1,0 +1,10 @@
+name: priority
+title: InSpec Profile
+maintainer: The Authors
+copyright: The Authors
+copyright_email: you@example.com
+license: Apache-2.0
+summary: An InSpec Compliance Profile
+version: 0.1.0
+supports:
+  platform: os

--- a/test/fixtures/vault/secret/inspec/priority.json
+++ b/test/fixtures/vault/secret/inspec/priority.json
@@ -1,0 +1,5 @@
+{
+  "priority_check_always_vault":"value_from_vault",
+  "priority_check_dsl_wins":"value_from_vault",
+  "priority_check_variable_outcome":"value_from_vault"
+}

--- a/test/integration/inspec_vault_test.rb
+++ b/test/integration/inspec_vault_test.rb
@@ -20,7 +20,27 @@ describe "the inspec-vault plugin" do
   end
 
   # Try inheritance
-  # Try override
-  # Try custome prefix
-  # Try custom priority
+  # Try custom prefix
+
+  describe "when run with custom priority values" do
+    def run_priority_test(priority, first_should_pass)
+      cmd = "exec #{profile_fixtures}/priority --reporter json"
+      env['INSPEC_VAULT_PRIORITY'] = priority
+      result = run_inspec_with_vault_plugin(cmd, env: env)
+      json = JSON.parse(result.stdout)
+      ctls = json.dig("profiles", 0, "controls")
+      assert_equal "passed", ctls.dig(0,"results", 0, "status"), ctls.dig(0, "id")
+      assert_equal "passed", ctls.dig(1,"results", 0, "status"), ctls.dig(1, "id")
+      assert_equal (first_should_pass ? "passed" : "failed"), ctls.dig(2,"results", 0, "status"), ctls.dig(2, "id")
+      assert_equal (first_should_pass ? "failed" : "passed"), ctls.dig(2,"results", 1, "status"), ctls.dig(2, "id")
+    end
+
+    it "should be overridden by DSL when the priority is low" do
+      run_priority_test(25, true)
+    end
+
+    it "should override DSL when the priority is high" do
+      run_priority_test(75, false)
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Implements a customizable input priority option, default 60.

## Related Issue

Closes #17. Documented on #21 .

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
