### PR TITLE
Implement lookup for full Vault paths and secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ With that value stored, Chef InSpec will now be able to retrieve the value.
 
 ## What This Plugin Does
 
-With the inspec-vault plugin enabled, Chef InSpec will contact the Vault server whenever an `input()` DSL call appears in profile control code. For example, whenever profile code like this is encountered:
+With the inspec-vault plugin enabled, Chef InSpec will contact the Vault server whenever an `input()` DSL call appears in profile control code. If a secret located at the given location, InSpec will use this value. Otherwise it will fall back to other means of resolving the input, such as other plugins, profile metadata or CLI values.
+
+Chef InSpec will determine a secret lookup path and access Vault, returning the value it found.
+
+### Profile Based Lookup
+
+The default mode allows you to use profile-specific secrets.
+
+For example, whenever profile code like this is encountered:
 
 ```ruby
 # In profile "my_profile"
@@ -53,7 +61,19 @@ describe input("some_input") do
 end
 ```
 
-Chef InSpec will determine a secret lookup path and access Vault. With no other settings, Chef InSpec will look for a Vault secret located at `secret/inspec/my_profile` with a key named "some_input". Chef InSpec will use the Vault secret if found, but otherwise it will fall back to other means of resolving the input, such as the profile metadata or CLI values.
+With no other settings, Chef InSpec will look for a Vault secret located at `secret/inspec/my_profile` with a key named `some_input`. The `my_profile` part of the path is the name of your InSpec profile. The `inspec` part comes from the `path_prefix` setting.
+
+### Absolute Path Lookup
+
+In some cases, you want to access global information and not something related to a specific profile. For this case, qualify the path in absolute syntax with a starting `/`, like this:
+
+```ruby
+describe input("/configuration/webserver/password")
+ it { should cmp "some_expected_value" }
+end
+```
+
+This will result in access to `secret/configuration/webserver` and the return of value of the `password` key within.
 
 ## Configuring the Plugin
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ describe input("/configuration/webserver/password")
 end
 ```
 
-This will result in access to `secret/configuration/webserver` and the return of value of the `password` key within.
+In this case, Chef InSpec searches the `secret/configuration/webserver` document and returns the value of the `password` key.
 
 ## Configuring the Plugin
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ With that value stored, Chef InSpec will now be able to retrieve the value.
 
 ## What This Plugin Does
 
-With the inspec-vault plugin enabled, Chef InSpec will contact the Vault server whenever an `input()` DSL call appears in profile control code. If a secret located at the given location, InSpec will use this value. Otherwise it will fall back to other means of resolving the input, such as other plugins, profile metadata or CLI values.
+With the inspec-vault plugin enabled, Chef InSpec will contact the Vault server whenever an `input()` DSL call appears in profile control code. If a secret is located at the given location, InSpec will use this value. Otherwise it will fall back to other means of resolving the input, such as other plugins, profile metadata or CLI values. See https://www.inspec.io/docs/reference/inputs/ for an explanation on input precedence.
 
 Chef InSpec will determine a secret lookup path and access Vault, returning the value it found.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ With that value stored, Chef InSpec will now be able to retrieve the value.
 
 ## What This Plugin Does
 
-With the inspec-vault plugin enabled, Chef InSpec will contact the Vault server whenever an `input()` DSL call appears in profile control code. If a secret is located at the given location, InSpec will use this value. Otherwise it will fall back to other means of resolving the input, such as other plugins, profile metadata or CLI values. See https://www.inspec.io/docs/reference/inputs/ for an explanation on input precedence.
+With the inspec-vault plugin enabled, whenever an `input()` DSL call appears in profile control code, Chef InSpec contacts the Vault server. If the secret is located in Vault, Chef InSpec uses this value. Otherwise, it searches for other sources to resolve the input, such as other plugins, profile metadata, or CLI values, as described in the Chef InSpec [input precedence](https://www.inspec.io/docs/reference/inputs/) documentation. 
 
-Chef InSpec will determine a secret lookup path and access Vault, returning the value it found.
 
 ### Profile Based Lookup
 
@@ -61,11 +60,11 @@ describe input("some_input") do
 end
 ```
 
-With no other settings, Chef InSpec will look for a Vault secret located at `secret/inspec/my_profile` with a key named `some_input`. The `my_profile` part of the path is the name of your InSpec profile. The `inspec` part comes from the `path_prefix` setting.
+With no other settings, Chef InSpec looks for a Vault secret located at `secret/inspec/my_profile` with a key named `some_input`, where `inspec` is derived from the `path_prefix` setting and `my_profile` is the name of this InSpec profile.
 
 ### Absolute Path Lookup
 
-In some cases, you want to access global information and not something related to a specific profile. For this case, qualify the path in absolute syntax with a starting `/`, like this:
+To access global information instead of a value related to a specific profile, qualify the path in absolute syntax with a starting `/`. For example:
 
 ```ruby
 describe input("/configuration/webserver/password")
@@ -131,4 +130,3 @@ Please have a look at our CONTRIBUTING.md for general guidelines.
 Run `bundle exec rake test:lint` for linting, `bundle exec rake test:unit` for unit tests, and `bundle exec rake test:integration` for integration tests.
 
 Note that integration tests will download and run Vault server locally.
-


### PR DESCRIPTION
In our experience, Vault secrets are rarely stored on a per-profile level but more as some sort of global configuration data. As the current plugin implementation does not allow access to those paths, this PR was created.

## Description

The usual way of working is not changed. If the input name starts with a forward slash, this is taken as an indicator for a fully specified path. In that case the last part of the input is treated as the key and everything before as the path.

## Related Issue
- Lookup for arbitrary Vault secret paths #29 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
