### PR TITLE
Implement databag fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In this case, Chef InSpec searches the `secret/configuration/webserver` document
 
 ## Usage with Test Kitchen
 
-To allow for more dev/prod parity, this input plugin detects if it is called from within Test Kitchen. As tests should limit access to third party systems, by default the plugin will revert on using the `data_bags_path` from kitchen's `provisioner` section:
+To allow for more development/production parity, this input plugin detects if it is called from within Test Kitchen. As tests should limit access to third party systems, by default the plugin will revert on using the `data_bags_path` from kitchen's `provisioner` section:
 
 ```yaml
 suites:
@@ -90,7 +90,7 @@ With this configuration, the databag at `test/integration/data_bags/inspec` will
 
 The databag fallback mode and the databag or item names can be configured for the plugin.
 
-Please note, that support for `load_plugins` was introduced in version 1.3.2 of the `kitchen-inspec` verifier plugin. Earlier versions are unable to load InSpec V2 plugins.
+Support for `load_plugins` was introduced in version 1.3.2 of the `kitchen-inspec` verifier plugin. Earlier versions are unable to load InSpec V2 plugins.
 
 ## Configuring the Plugin
 
@@ -115,19 +115,19 @@ This plugin supports the following options:
 
 ### databag_fallback
 
-A boolean that indicates if the plugin should use a data bag within Test Kitchen; default value is "true". This allows mocking a Vault server in development instances.
+A boolean that indicates if the plugin should use a data bag within Test Kitchen. The default value is "true". This allows for mocking a Vault server in development instances.
 
 ### INSPEC_DATABAG_ITEM
 
 ### databag_item
 
-A string with the name of the data bag item to use, if `databag_fallback` is true; default value is "vault".
+A string with the name of the data bag item to use. If `databag_fallback` is `true`, then the default value is "vault".
 
 ### INSPEC_DATABAG_NAME
 
 ### databag_name
 
-A string with the name of the data bag to use, if `databag_fallback` is true; default value is "inspec".
+A string with the name of the data bag to use. If `databag_fallback` is `true`, then the default value is "inspec".
 
 ### INSPEC_VAULT_MOUNT_POINT
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ end
 
 In this case, Chef InSpec searches the `secret/configuration/webserver` document and returns the value of the `password` key.
 
-## Usage with TestKitchen
+## Usage with Test Kitchen
 
-To allow for more dev/prod parity, this input plugin detects if it is called from within TestKitchen. As tests should limit access to third party systems, by default the plugin will revert on using the `data_bags_path` from kitchen's `provisioner` section:
+To allow for more dev/prod parity, this input plugin detects if it is called from within Test Kitchen. As tests should limit access to third party systems, by default the plugin will revert on using the `data_bags_path` from kitchen's `provisioner` section:
 
 ```yaml
 suites:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ end
 
 In this case, Chef InSpec searches the `secret/configuration/webserver` document and returns the value of the `password` key.
 
+## Usage with TestKitchen
+
+To allow for more dev/prod parity, this input plugin detects if it is called from within TestKitchen. As tests should limit access to third party systems, by default the plugin will revert on using the `data_bags_path` from kitchen's `provisioner` section:
+
+```yaml
+suites:
+  - name: default
+    verifier:
+      load_plugins: true
+    data_bags_path: "test/integration/data_bags"
+```
+
+With this configuration, the databag at `test/integration/data_bags/inspec` will be accessed and the contents of the `vault.json` file within this directory get parsed. Any Vault lookups will be evaluated against the contained data.
+
+The databag fallback mode and the databag or item names can be configured for the plugin.
+
+Please note, that support for `load_plugins` was introduced in version 1.3.2 of the `kitchen-inspec` verifier plugin. Earlier versions are unable to load InSpec V2 plugins.
+
 ## Configuring the Plugin
 
 Each plugin option may be set either as an environment variable, or as a plugin option in your Chef InSpec configuration file at `~/.inspec/config.json`. For example, to set the `prefix_path` option in the config file, lay out the config file as follows:
@@ -92,6 +110,24 @@ Each plugin option may be set either as an environment variable, or as a plugin 
 Config file option names are always lowercase.
 
 This plugin supports the following options:
+
+### INSPEC_DATABAG_FALLBACK
+
+### databag_fallback
+
+A boolean that indicates if the plugin should use a data bag within Test Kitchen; default value is "true". This allows mocking a Vault server in development instances.
+
+### INSPEC_DATABAG_ITEM
+
+### databag_item
+
+A string with the name of the data bag item to use, if `databag_fallback` is true; default value is "vault".
+
+### INSPEC_DATABAG_NAME
+
+### databag_name
+
+A string with the name of the data bag to use, if `databag_fallback` is true; default value is "inspec".
 
 ### INSPEC_VAULT_MOUNT_POINT
 

--- a/lib/inspec-vault/input.rb
+++ b/lib/inspec-vault/input.rb
@@ -3,32 +3,40 @@ require "vault"
 # See https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md#implementing-input-plugins
 
 module InspecPlugins::Vault
+  class ConfigurationError < RuntimeError; end
+  class DatabagNotFoundError < RuntimeError; end
+
   class Input < Inspec.plugin(2, :input)
 
     attr_reader :plugin_conf
     attr_reader :mount_point
     attr_reader :path_prefix
-    attr_reader :vault
     attr_reader :priority
     attr_reader :input_name
-    attr_reader :logger
+    attr_reader :databag_fallback
+    attr_reader :databag_name
+    attr_reader :databag_item
+
+    attr_writer :databag
+    attr_writer :inspec_config
+    attr_writer :logger
+    attr_writer :vault
 
     def initialize
-      @plugin_conf = Inspec::Config.cached.fetch_plugin_config("inspec-vault")
-
-      @logger = Inspec::Log
       logger.debug format("Inspec-Vault plugin version %s", VERSION)
+
+      @plugin_conf = inspec_config.fetch_plugin_config("inspec-vault")
 
       @mount_point = fetch_plugin_setting("mount_point", "secret")
       @path_prefix = fetch_plugin_setting("path_prefix", "inspec")
+      @databag_fallback = fetch_plugin_setting("databag_fallback", true)
+      @databag_name = fetch_plugin_setting("databag_name", "inspec")
+      @databag_item = fetch_plugin_setting("databag_item", "vault")
 
       # We need priority to be numeric; even though env vars or JSON may present it as string - hence the to_i
       @priority = fetch_plugin_setting("priority", 60).to_i
 
-      @vault = Vault::Client.new(
-        address: fetch_vault_setting("vault_addr"),
-        token: fetch_vault_setting("vault_token")
-      )
+      logger.info "Running from TestKitchen" if inside_testkitchen?
     end
 
     # What priority should an input value recieve from us?
@@ -63,15 +71,45 @@ module InspecPlugins::Vault
         path = logical_path path.join("/")
       end
 
-      logger.info format("Reading Vault secret from %s", path)
+      fetch_value(path, item)
+    end
+
+    private
+
+    def inspec_config
+      @inspec_config ||= Inspec::Config.cached
+    end
+
+    def logger
+      @logger ||= Inspec::Log
+    end
+
+    def vault
+      @vault ||= Vault::Client.new(
+        address: fetch_vault_setting("vault_addr"),
+        token: fetch_vault_setting("vault_token")
+      )
+    end
+
+    def fetch_value(path, item)
+      if inside_testkitchen? && use_databags?
+        fetch_databag_value(path, item)
+      else
+        fetch_vault_value(path, item)
+      end
+    end
+
+    def fetch_vault_value(path, item)
+      logger.info format("Reading Vault secret %s/%s",
+                         path.sub(/.data/, ""), item)
+
       vault.with_retries(Vault::HTTPConnectionError) do
         doc = vault.logical.read(path)
+
         # Keys from vault are always symbolized
         return doc.data[:data][item.to_sym] if doc
       end
     end
-
-    private
 
     # Assumption for profile based lookups: inputs have been stored on documents named
     # for their profiles, and each input has a key-value pair in the document.
@@ -104,6 +142,54 @@ module InspecPlugins::Vault
 
     def fetch_vault_setting(setting_name)
       ENV[setting_name.upcase] || plugin_conf[setting_name]
+    end
+
+    # Check if this is called from within TestKitchen
+    def inside_testkitchen?
+      !! defined?(::Kitchen)
+    end
+
+    # Access to kitchen data
+    def kitchen
+      require "binding_of_caller"
+      binding.callers.find { |b| b.frame_description == "verify" }.receiver
+    end
+
+    # Return provisioner config
+    def kitchen_provisioner_config
+      kitchen.provisioner.send(:provided_config)
+    end
+
+    def use_databags?
+      databag_fallback.to_s == "true"
+    end
+
+    def databag_path
+      unless kitchen_provisioner_config[:data_bags_path]
+        raise ConfigurationError.new("Need to set provisioner/data_bags_path in Kitchen configuration")
+      end
+
+      File.join(kitchen_provisioner_config[:data_bags_path], databag_name, databag_item + ".json")
+    end
+
+    def databag
+      raise DatabagNotFoundError.new("Databag item '#{databag_path}' not found") unless File.exist? databag_path
+
+      @databag ||= JSON.load File.read(databag_path)
+    end
+
+    def fetch_databag_value(path, item)
+      logger.info format("Mocking Vault secret '%s/%s' from databag '%s' and item '%s'",
+                         path.sub(/.data/, ""), item,
+                         databag_name, item)
+
+      # Path starts with "#{mount_point}/data", which is not needed
+      remaining_path = path.split("/")[2..-1].join("/")
+
+      jmes_path = remaining_path.tr("/", ".")
+      path_contents = JMESPath.search(jmes_path, databag)
+
+      path_contents[item] if path_contents
     end
   end
 end

--- a/lib/inspec-vault/input.rb
+++ b/lib/inspec-vault/input.rb
@@ -150,6 +150,7 @@ module InspecPlugins::Vault
     end
 
     # Access to kitchen data
+    # TODO: Switch to official API discussed in test-kitchen/test-kitchen#1674
     def kitchen
       require "binding_of_caller"
       binding.callers.find { |b| b.frame_description == "verify" }.receiver

--- a/test/unit/plugin_def_test.rb
+++ b/test/unit/plugin_def_test.rb
@@ -44,8 +44,8 @@ describe InspecPlugins::Vault::Plugin do
   end
 
   # Plugins can support several different activator hooks, each of which has a type.
-  # Since this is (primarily) a CliCommand plugin, we'd expect to see that among our types.
-  it "should include a cli_command activator hook" do
+  # Since this is (primarily) an Input plugin, we'd expect to see that among our types.
+  it "should include a input activator hook" do
     status.plugin_types.must_include(:input)
   end
 end


### PR DESCRIPTION
## Description

Implement the possibility to fall back to a databag when used in Test Kitchen, just like with chef-vault.

## Related Issue

Way of Testing with Test Kitchen #31 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
