### PR TITLE
Update URL point to new location for plugin docs.  Obvious fix.

### DIFF
--- a/lib/inspec-vault/input.rb
+++ b/lib/inspec-vault/input.rb
@@ -34,7 +34,7 @@ module InspecPlugins::Vault
     # What priority should an input value recieve from us?
     # This plgin does not currently allow setting this on a per-input basis,
     # so they all recieve the same "default" value.
-    # Implements https://github.com/inspec/inspec/blob/master/docs/dev/plugins.md#default_priority
+    # Implements https://github.com/inspec/inspec/blob/master/dev-docs/plugins.md#default_priority
     def default_priority
       priority
     end


### PR DESCRIPTION
## Description
This plugin is cited in Inspec documentation as a reference plugin. Some peers and I reviewed this file and noticed the documentation structure for inspect core has changed. Fixing this so others can quickly determine how to use `default_priority` in the context of this and other input plugins.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:

- [x] I have read the **CONTRIBUTING** document (presumably, the one in Inspec core).
